### PR TITLE
Remove Gleam namespace + use imports from editor + use external libs

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,6 @@
     <title>GLEAM visual novel creator</title>
     <link rel="stylesheet" type="text/css" href="css/editor.css">
     <link rel="stylesheet" type="text/css" href="css/player.css">
-    <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
-    <script src="build/gleam-player.js"></script>
 </head>
 <body>
 <main id="gleam-editor-launcher">
@@ -132,7 +130,7 @@
     </section>
 </main>
     <script type="module">
-        import { attach_editor } from './js/gleam-editor.js';
+        import { attach_editor } from './build/gleam-editor.js';
         // FIXME give a real api for this.  question is, how do i inject into the editor AND the player
         window.addEventListener('load', ev => {
             let launcher = attach_editor();
@@ -144,13 +142,13 @@
             let script;
             if (json) {
                 // TODO error handling here, probably
-                script = Gleam.MutableScript.from_json(JSON.parse(json));
+                script = MutableScript.from_json(JSON.parse(json));
             }
             else {
-                script = new Gleam.MutableScript;
-                script.add_role(new Gleam.Stage('stage'));
+                script = new MutableScript;
+                script.add_role(new Stage('stage'));
             }
-            editor.load_script(script, new Gleam.NullAssetLibrary);
+            editor.load_script(script, new NullAssetLibrary);
             return;
             //*/
 
@@ -160,11 +158,11 @@
             let root = 'res/prompt2-itchyitchy-final/';
             let root_url = new URL(root, document.location);
             //root_url = new URL('https://apps.veekun.com/flora-cutscenes/res/prompt2-itchyitchy-final/');
-            let library = new Gleam.RemoteAssetLibrary(root_url);
+            let library = new RemoteAssetLibrary(root_url);
             let xhr = new XMLHttpRequest;
             xhr.addEventListener('load', ev => {
                 // FIXME handle errors yadda yadda
-                let script = Gleam.MutableScript.from_legacy_json(JSON.parse(xhr.responseText));
+                let script = MutableScript.from_legacy_json(JSON.parse(xhr.responseText));
                 editor.load_script(script, library);
             });
             // XXX lol

--- a/js/gleam-editor.js
+++ b/js/gleam-editor.js
@@ -20,7 +20,11 @@ import {
     Director,
     Player,
 } from './player/gleam-player.js'
-import {DialogOverlay, PopupListOverlay, accept_drop} from './ui.js';
+import {
+    DialogOverlay,
+    PopupListOverlay,
+    accept_drop,
+} from './ui.js';
 
 /**
  * @param {string} a

--- a/js/gleam-editor.js
+++ b/js/gleam-editor.js
@@ -1,14 +1,26 @@
-import {html, render} from 'https://unpkg.com/lit-html?module';
-import {repeat} from 'https://unpkg.com/lit-html/directives/repeat.js?module';
-
+import "../node_modules/sortablejs/Sortable.js"
+import {html, render} from "../node_modules/lit-html/lit-html.js";
+import {
+    mk,
+    svg_icon_from_path,
+    Step,
+    Beat,
+    Role,
+    Actor,
+    Stage,
+    Curtain,
+    Mural,
+    DialogueBox,
+    Jukebox,
+    PictureFrame,
+    Character,
+    AssetLibrary,
+    RemoteAssetLibrary,
+    Script,
+    Director,
+    Player,
+} from './player/gleam-player.js'
 import {DialogOverlay, PopupListOverlay, accept_drop} from './ui.js';
-import {mk} from './player/util.js';
-
-if (! window.Gleam) {
-    throw new Error("Gleam player must be loaded first!");
-}
-
-let svg_icon_from_path = Gleam.svg_icon_from_path;
 
 /**
  * @param {string} a
@@ -120,7 +132,7 @@ function make_inline_string_editor(initial_value, onchange) {
 }
 
 // Dummy implementation that can't find any files, used in a fresh editor
-class NullAssetLibrary extends Gleam.AssetLibrary {
+class NullAssetLibrary extends AssetLibrary {
     load_image(path, element) {
         let asset = this.asset(path);
         asset.used = true;
@@ -155,7 +167,7 @@ function _entry_to_url(entry) {
     }
 }
 // FIXME 'used' isn't really handled very well; there's no way to "un-use" something.  but there's also no way to delete a pose/track yet
-class EntryAssetLibrary extends Gleam.AssetLibrary {
+class EntryAssetLibrary extends AssetLibrary {
     constructor(directory_entry) {
         super();
         this.directory_entry = directory_entry;
@@ -262,7 +274,7 @@ class EntryAssetLibrary extends Gleam.AssetLibrary {
     }
 }
 
-class FileAssetLibrary extends Gleam.AssetLibrary {
+class FileAssetLibrary extends AssetLibrary {
     constructor(files) {
         super();
         for (let file of files) {
@@ -315,7 +327,7 @@ class FileAssetLibrary extends Gleam.AssetLibrary {
 }
 
 // Subclass of Script that knows how to edit itself
-class MutableScript extends Gleam.Script {
+class MutableScript extends Script {
     add_role(role) {
         // FIXME abort if name is already in use
         this._add_role(role);
@@ -341,7 +353,7 @@ class MutableScript extends Gleam.Script {
             return this.beats[beat_index - 1].create_next();
         }
         else {
-            return Gleam.Beat.create_first(this.roles);
+            return Beat.create_first(this.roles);
         }
     }
 
@@ -840,8 +852,8 @@ class ImportDialogueDialog extends DialogOverlay {
                     if (role) {
                         // TODO this should be optional
                         // FIXME it's also technically invalid, fool
-                        add_step(new Gleam.Step(role, 'pose', []));
-                        add_step(new Gleam.Step(role, 'say', [phrase]));
+                        add_step(new Step(role, 'pose', []));
+                        add_step(new Step(role, 'say', [phrase]));
                         continue;
                     }
                     else {
@@ -854,7 +866,7 @@ class ImportDialogueDialog extends DialogOverlay {
 
                 // Fallback case
                 if (fail_reason) {
-                    let el = add_step(new Gleam.Step(stage, 'note', [`[${fail_reason}] ${paragraph}`]));
+                    let el = add_step(new Step(stage, 'note', [`[${fail_reason}] ${paragraph}`]));
                     el.classList.add('-import-dialogue-error');
                 }
             }
@@ -974,7 +986,7 @@ class RoleEditor {
                 // TODO?
                 args.push(null);
             }
-            this.main_editor.script_panel.begin_step_drag(new Gleam.Step(this.role, step_kind_name, args));
+            this.main_editor.script_panel.begin_step_drag(new Step(this.role, step_kind_name, args));
         });
     }
 
@@ -1056,24 +1068,24 @@ class RoleEditor {
 // Note that this has no role_type_name, which prevents you from creating one
 class StageEditor extends RoleEditor {
 }
-StageEditor.prototype.ROLE_TYPE = Gleam.Stage;
+StageEditor.prototype.ROLE_TYPE = Stage;
 StageEditor.prototype.CLASS_NAME = 'gleam-editor-role-stage';
 
 class CurtainEditor extends RoleEditor {
 }
-CurtainEditor.prototype.ROLE_TYPE = Gleam.Curtain;
+CurtainEditor.prototype.ROLE_TYPE = Curtain;
 CurtainEditor.role_type_name = 'curtain';
 CurtainEditor.prototype.CLASS_NAME = 'gleam-editor-role-curtain';
 
 class MuralEditor extends RoleEditor {
 }
-MuralEditor.prototype.ROLE_TYPE = Gleam.Mural;
+MuralEditor.prototype.ROLE_TYPE = Mural;
 MuralEditor.role_type_name = 'mural';
 MuralEditor.prototype.CLASS_NAME = 'gleam-editor-role-mural';
 
 class DialogueBoxEditor extends RoleEditor {
 }
-DialogueBoxEditor.prototype.ROLE_TYPE = Gleam.DialogueBox;
+DialogueBoxEditor.prototype.ROLE_TYPE = DialogueBox;
 DialogueBoxEditor.role_type_name = 'dialogue box';
 DialogueBoxEditor.prototype.CLASS_NAME = 'gleam-editor-role-dialoguebox';
 
@@ -1134,7 +1146,7 @@ class JukeboxEditor extends RoleEditor {
         this.track_list.append(fragment);
     }
 }
-JukeboxEditor.prototype.ROLE_TYPE = Gleam.Jukebox;
+JukeboxEditor.prototype.ROLE_TYPE = Jukebox;
 JukeboxEditor.role_type_name = 'jukebox';
 JukeboxEditor.prototype.CLASS_NAME = 'gleam-editor-role-jukebox';
 
@@ -1178,8 +1190,8 @@ class PictureFrameEditor extends RoleEditor {
             // TODO insert_step does a lot of work; would be nice to extend it
             // to insert_steps, which adds a block of steps in bulk somewhere
             for (let [name, pose] of Object.entries(this.role.poses)) {
-                script.insert_step(new Gleam.Step(this.role, 'show', [name]), script.steps.length);
-                script.insert_step(new Gleam.Step(stage, 'pause', []), script.steps.length);
+                script.insert_step(new Step(this.role, 'show', [name]), script.steps.length);
+                script.insert_step(new Step(stage, 'pause', []), script.steps.length);
             }
         });
 
@@ -1426,7 +1438,7 @@ class PictureFrameEditor extends RoleEditor {
         this.render_pose_editor();
     }
 }
-PictureFrameEditor.prototype.ROLE_TYPE = Gleam.PictureFrame;
+PictureFrameEditor.prototype.ROLE_TYPE = PictureFrame;
 PictureFrameEditor.role_type_name = 'picture frame';
 PictureFrameEditor.prototype.CLASS_NAME = 'gleam-editor-role-pictureframe';
 
@@ -1490,7 +1502,7 @@ class CharacterEditor extends PictureFrameEditor {
         }
         prop_editor.addEventListener('click', ev => {
             let dialogue_boxes = this.main_editor.script.roles.filter(
-                role => role instanceof Gleam.DialogueBox);
+                role => role instanceof DialogueBox);
             if (! dialogue_boxes.length) {
                 dialogue_boxes.push(null);
             }
@@ -1561,7 +1573,7 @@ class CharacterEditor extends PictureFrameEditor {
         }
     }
 }
-CharacterEditor.prototype.ROLE_TYPE = Gleam.Character;
+CharacterEditor.prototype.ROLE_TYPE = Character;
 CharacterEditor.role_type_name = 'character';
 CharacterEditor.prototype.CLASS_NAME = 'gleam-editor-role-character';
 
@@ -1688,7 +1700,7 @@ class AssetsPanel extends Panel {
         else if (library instanceof FileAssetLibrary) {
             this.source_text.textContent = 'local files';
         }
-        else if (library instanceof Gleam.RemoteAssetLibrary) {
+        else if (library instanceof RemoteAssetLibrary) {
             this.source_text.textContent = 'via the web';
         }
         else {
@@ -2392,7 +2404,7 @@ class Editor {
         this.script_slot = slot;
         this.script = script;
         this.library = library;
-        this.player = new Gleam.Player(this.script, library);
+        this.player = new Player(this.script, library);
         // XXX stupid hack, disable the loading overlay, which for local files will almost certainly not work
         this.player.loaded = true;
         this.player.loading_overlay.hide();
@@ -2541,7 +2553,7 @@ class EditorLauncher {
 
             // Create a fresh new script
             let script = new MutableScript;
-            script.add_role(new Gleam.Stage('stage'));
+            script.add_role(new Stage('stage'));
             script.title = this.new_form.elements['title'].value;
             script.subtitle = this.new_form.elements['subtitle'].value;
             script.author = this.new_form.elements['author'].value;
@@ -2563,11 +2575,11 @@ class EditorLauncher {
         let root_url = new URL(root, document.location);
         //root_url = new URL('https://apps.veekun.com/flora-cutscenes/res/prompt2-itchyitchy-final/');
         // TODO should get the asset root from the script...?  that's a thing in old ones but not so much new ones
-        let library = new Gleam.RemoteAssetLibrary(root_url);
+        let library = new RemoteAssetLibrary(root_url);
         let xhr = new XMLHttpRequest;
         xhr.addEventListener('load', ev => {
             // FIXME handle errors yadda yadda
-            let script = Gleam.MutableScript.from_legacy_json(JSON.parse(xhr.responseText));
+            let script = MutableScript.from_legacy_json(JSON.parse(xhr.responseText));
             // FIXME editor doesn't know how to handle something not already in a save slot
             this.editor.load_script(script, library, null);
             // TODO show some kinda loading indicator

--- a/js/player/gleam-player.js
+++ b/js/player/gleam-player.js
@@ -30,12 +30,8 @@ import Step from "./step";
 import {mk, svg_icon_from_path} from "./util";
 import {VERSION} from "./version";
 
-window.Gleam = (function() {
-
-let ret = {
-    VERSION: VERSION,
-};
-for (let obj of [
+export {
+    VERSION,
     mk,
     svg_icon_from_path,
 
@@ -58,9 +54,4 @@ for (let obj of [
     Script,
     Director,
     Player,
-])
-{
-    ret[obj.name] = obj;
 }
-return ret;
-})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,10 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "lit-html": "^1.4.0",
+        "sortablejs": "^1.13.0"
+      },
       "devDependencies": {
         "rollup": "^2.46.0"
       }
@@ -22,6 +26,11 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/lit-html": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.0.tgz",
+      "integrity": "sha512-cgaqPSgqHRaTH/P1DnWD/dQxudtrHqD0xo1AoyOGJZir2rXgsvTg77z6Pitwk9B+kL23EakD62HV3x8sT01aWQ=="
+    },
     "node_modules/rollup": {
       "version": "2.46.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.46.0.tgz",
@@ -36,6 +45,11 @@
       "optionalDependencies": {
         "fsevents": "~2.3.1"
       }
+    },
+    "node_modules/sortablejs": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.13.0.tgz",
+      "integrity": "sha512-RBJirPY0spWCrU5yCmWM1eFs/XgX2J5c6b275/YyxFRgnzPhKl/TDeU2hNR8Dt7ITq66NRPM4UlOt+e5O4CFHg=="
     }
   },
   "dependencies": {
@@ -46,6 +60,11 @@
       "dev": true,
       "optional": true
     },
+    "lit-html": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.0.tgz",
+      "integrity": "sha512-cgaqPSgqHRaTH/P1DnWD/dQxudtrHqD0xo1AoyOGJZir2rXgsvTg77z6Pitwk9B+kL23EakD62HV3x8sT01aWQ=="
+    },
     "rollup": {
       "version": "2.46.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.46.0.tgz",
@@ -54,6 +73,11 @@
       "requires": {
         "fsevents": "~2.3.1"
       }
+    },
+    "sortablejs": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.13.0.tgz",
+      "integrity": "sha512-RBJirPY0spWCrU5yCmWM1eFs/XgX2J5c6b275/YyxFRgnzPhKl/TDeU2hNR8Dt7ITq66NRPM4UlOt+e5O4CFHg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,5 +4,9 @@
   },
   "scripts": {
     "build": "rollup --config"
+  },
+  "dependencies": {
+    "lit-html": "^1.4.0",
+    "sortablejs": "^1.13.0"
   }
 }

--- a/player.html
+++ b/player.html
@@ -3,21 +3,25 @@
 <head>
     <meta charset="utf8">
     <title>GLEAM</title>
-    <link rel="stylesheet" type="text/css" href="player.css">
-    <script src="build/gleam-player.js"></script>
+    <link rel="stylesheet" type="text/css" href="css/player.css">
 </head>
 <body class="gleam-body">
-    <script>
+    <script type="module">
         // FIXME give a real api for this.  question is, how do i inject into the editor AND the player
+        import {
+            RemoteAssetLibrary,
+            Script,
+            Player,
+        } from "./build/gleam-player.js";
         window.addEventListener('load', ev => {
             let root_url = new URL('https://apps.veekun.com/flora-cutscenes/res/prompt2-itchyitchy-final/');
             root_url = new URL('/res/circlet-of-the-sun/', window.location);
-            let library = new Gleam.RemoteAssetLibrary(root_url);
+            let library = new RemoteAssetLibrary(root_url);
             let xhr = new XMLHttpRequest;
             xhr.addEventListener('load', ev => {
                 // FIXME handle errors yadda yadda
-                let script = Gleam.Script.from_json(JSON.parse(xhr.responseText));
-                let player = new Gleam.Player(script, library);
+                let script = Script.from_json(JSON.parse(xhr.responseText));
+                let player = new Player(script, library);
                 player.inject(document.body);
             });
             // XXX lol

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,16 @@
-export default {
-  input: 'js/player/gleam-player.js',
-  output: {
-    file: 'build/gleam-player.js',
-    format: 'cjs'
+export default [
+  {
+    input: 'js/player/gleam-player.js',
+    output: {
+      file: 'build/gleam-player.js',
+      sourcemap: true,
+    },
+  },
+  {
+    input: 'js/gleam-editor.js',
+    output: {
+      file: 'build/gleam-editor.js',
+      sourcemap: true,
+    },
   }
-};
+];


### PR DESCRIPTION
As discussed I dropped the Gleam namespace to use JavaScript modules, it enable to use import from the editor code.

To finish this part of the refactoring I've also changed external JavaScript files to used them as NPM modules since there is now the infrastructure for it, so the `gleam-editor.js` is now self-contained.

The build now generates two files :
- a standalone `gleam-player.js`
- a standalone `gleam-editor.js` that embed the player

I've tried to minimise the changes to the files.